### PR TITLE
Prevent buttons from stealing focus.

### DIFF
--- a/src/keyboard.vue
+++ b/src/keyboard.vue
@@ -203,6 +203,7 @@
 				:data-text="btn.value"
 				:data-action="btn.action.name"
 				@click.prevent="btn.action.callable"
+				@mousedown.prevent=""
 			>{{ btn.value }}</button>
 		</div>
 	</aside>


### PR DESCRIPTION
It allows the associated input element to stay focused, especially
to keep the associated CSS :focus style if any while typing on the
keyboard.

Hope it can make sense to you :)