### PR TITLE
Added slot support for buttons

### DIFF
--- a/src/keyboard.vue
+++ b/src/keyboard.vue
@@ -1,8 +1,9 @@
 <template>
   <aside class="vue-keyboard" role="application" :class="{ full: full, empty: empty, valid: valid, invalid: !valid }" :data-value="value" :data-layout="layout">
-    <div role="row" class="vue-keyboard-row" v-for="row in buttons" :data-keys="row.length">
+    <div role="row" class="vue-keyboard-row" v-for="(row, rowIndex) in buttons" :key="rowIndex" :data-keys="row.length">
       <button
-        v-for="btn in row"
+        v-for="(btn, btnIndex) in row"
+        :key="btnIndex"
         class="vue-keyboard-key"
         role="button"
         :class="btn.type"
@@ -11,7 +12,11 @@
         :data-action="btn.action.name"
         @click.prevent="btn.action.callable"
         @mousedown.prevent=""
-      >{{ btn.value }}</button>
+      >
+        <slot :name="btn.action.name || btn.value">
+          {{ btn.value }}
+        </slot>
+      </button>
     </div>
   </aside>
 </template>


### PR DESCRIPTION
Hi,

I've added support for named slots for each key in a layout. This enables you to render SVGs, images or whatever you'd like instead of plain text keys. This should close off https://github.com/martywallace/vue-keyboard/issues/14 and does not break existing functionality.

Slots use the action name for named actions, or the value for all other keys.

Example usage:

```vue
<vue-keyboard
  v-show="keyboardVisible"
  v-model="keyboardInput"
  :layouts="compactLayout"
>
  <template #backspace>
    <font-awesome icon="backspace" />
  </template>
  <template #q>
    <img src="q.png">
  </template>
</vue-keyboard>
```

I've also added the `key` attribute on the `v-for` loops as it's generally recommended and my linter complains. If you'd rather I remove this please let me know.